### PR TITLE
解释玩家对象不存在时的处理逻辑

### DIFF
--- a/modules/data.js
+++ b/modules/data.js
@@ -162,6 +162,12 @@ setInterval(() => {
     const players = mc.getOnlinePlayers(); // 获取在线玩家对象数组
     players.forEach(player => { // 遍历玩家对象数组
         let playerObj = getPlayerData(player.realName); // 获取玩家数据对象
+        
+        if(!playerObj){
+            //如果玩家不存在（为假人），则跳过
+            return;
+        }
+        
         let displayName = playerObj.chat_bubbles // 使用 replace 方法替换字符串中的占位符
             .replace(/\{player_name}/g, `${playerObj.nick}§r`)
             .replace(/\{player_msg}/g, playerObj.message)


### PR DESCRIPTION
当使用假人插件时，无法获取playerObj，会在服务器后台刷屏报错